### PR TITLE
Add travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: c
+
+before_install:
+  - wget https://sourceforge.net/projects/devkitpro/files/Automated%20Installer/devkitARMupdate.pl
+  - export DEVKITPRO=/home/travis/devkitPro
+  - export DEVKITARM=${DEVKITPRO}/devkitARM
+  - export PATH=$PATH:$DEVKITARM/bin
+
+install: 
+  - sudo perl devkitARMupdate.pl
+  
+script:
+  - make


### PR DESCRIPTION
Essentially the same deal as [here](https://github.com/nedwill/soundhax/pull/10), just adapted to compile rather than run a Python script. Auto-deploy can also be configured near-identically to how it is described [here](https://github.com/nedwill/soundhax/pull/16).