### PR TITLE
Fix crash at exit application

### DIFF
--- a/source/cleanup.c
+++ b/source/cleanup.c
@@ -48,6 +48,8 @@ static void *find_orphan() {
     if (IS_KERNEL_NON_SLAB_HEAP(child)) {
       /* object is allocated, therefore reachable */
       reachable[TOBJ_ADDR_TO_IDX(ktimer_base, current_timer)] = true;
+    } else if (child == (void *)TIMER2_NEXT_KERNEL) {
+      reachable[TOBJ_ADDR_TO_IDX(ktimer_base, current_timer)] = true;
     } else if (ktimer_base <= child && child < ktimer_end) {
       /* object is freed, next pointer is reachable */
       reachable[TOBJ_ADDR_TO_IDX(ktimer_base, child)] = true;
@@ -117,7 +119,6 @@ bool cleanup_uaf() {
   void *orphan = find_orphan();
   if (!orphan) {
     printf("[-] Failed to find orphan in KTimer linked list.\n");
-    return false;
   }
 
   printf("Found parent and orphan: %p -> %p\n", parent, orphan);


### PR DESCRIPTION
This patch contains these;

- reachable mark if child is TIMER2_NEXT_KERNEL;
  this action required for fix crash at exit hax app
- not exist orphan can be acceptable;
  we thought freed node will fill null, but maybe not.
  in my opinon, heap will not clear after free.
  I guess, many OS system implemented like this.

  but next node null also can acceptable, it's generic logic.
  so just parent mark to end node.
