### PR TITLE
Fix using wrong backdoor function and refactor function names

### DIFF
--- a/include/backdoor.h
+++ b/include/backdoor.h
@@ -10,9 +10,9 @@ Result svcMyBackdoor(s32 (*callback)(void));
 Result svcGlobalBackdoor(s32 (*callback)(void));
 
 /* Luma backdoor */
-void kmemcpy(void *dst, void *src, u32 len);
-void kwriteint(u32 *addr, u32 value);
-u32 kreadint(u32 *addr);
+void kmemcpy_debug(void *dst, void *src, u32 len);
+void kwriteint_debug(u32 *addr, u32 value);
+u32 kreadint_debug(u32 *addr);
 bool mybackdoor_installed();
 void print_array_wait(char *name, u32 *addr, u32 size);
 void *get_object_addr(Handle handle);

--- a/include/backdoor.h
+++ b/include/backdoor.h
@@ -6,14 +6,14 @@
 bool backdoor_installed;
 
 /* ASM SVC stubs */
-Result svcMyBackdoor(s32 (*callback)(void));
+Result svcDebugBackdoor(s32 (*callback)(void));
 Result svcGlobalBackdoor(s32 (*callback)(void));
 
 /* Luma backdoor */
 void kmemcpy_debug(void *dst, void *src, u32 len);
 void kwriteint_debug(u32 *addr, u32 value);
 u32 kreadint_debug(u32 *addr);
-bool mybackdoor_installed();
+bool debug_backdoor_installed();
 void print_array_wait(char *name, u32 *addr, u32 size);
 void *get_object_addr(Handle handle);
 /* Used in testing exploit */

--- a/include/backdoor.h
+++ b/include/backdoor.h
@@ -21,8 +21,8 @@ void kernel_randomstub(u32 *arg);
 bool get_timer_value(Handle timer, u64 *initial, u64 *interval);
 
 /* Real backdoor */
-u32 kreadint_real(u32 *addr);
-void kwriteint_real(u32 *addr, u32 value);
+u32 kreadint(u32 *addr);
+void kwriteint(u32 *addr, u32 value);
 bool global_backdoor_installed(void);
 /* Used in real exploit, must be called from kernel mode. */
 void install_global_backdoor(void);

--- a/source/backdoor.c
+++ b/source/backdoor.c
@@ -41,13 +41,13 @@ void kmemcpy_debug(void *dst, void *src, u32 len) {
   memcpy_dst = dst;
   memcpy_src = src;
   memcpy_len = len;
-  svcMyBackdoor((s32(*)(void)) & memcpy_int);
+  svcDebugBackdoor((s32(*)(void)) & memcpy_int);
 }
 
 void kwriteint_debug(u32 *addr, u32 value) {
   writeint_arg_addr = addr;
   writeint_arg_value = value;
-  svcMyBackdoor((s32(*)(void)) & writeint);
+  svcDebugBackdoor((s32(*)(void)) & writeint);
 }
 
 static void readint() { readint_res = *readint_arg; }
@@ -58,7 +58,7 @@ u32 kreadint_debug(u32 *addr) {
     return 0;
   }
   readint_arg = addr;
-  svcMyBackdoor((s32(*)(void)) & readint);
+  svcDebugBackdoor((s32(*)(void)) & readint);
   return readint_res;
 }
 
@@ -78,7 +78,7 @@ void kwriteint(u32 *addr, u32 value) {
   svcGlobalBackdoor((s32(*)(void)) & writeint);
 }
 
-bool mybackdoor_installed() {
+bool debug_backdoor_installed() {
   /* kwriteint won't have a side effect if it's not installed.
    * that svc is normally callable by userspace but returns
    * an error.
@@ -105,7 +105,7 @@ bool global_backdoor_installed() {
 }
 
 void print_array_wait(char *name, u32 *addr, u32 size) {
-  if (!mybackdoor_installed()) {
+  if (!debug_backdoor_installed()) {
     printf("can't print array, no backdoor\n");
     return;
   }
@@ -138,12 +138,12 @@ static void kernel_get_object_addr() {
 }
 
 void *get_object_addr(Handle handle) {
-  if (!mybackdoor_installed()) {
-    printf("get_object_addr: mybackdoor not installed.\n");
+  if (!debug_backdoor_installed()) {
+    printf("get_object_addr: debug_backdoor not installed.\n");
     return NULL;
   }
   get_object_handle = handle;
-  svcMyBackdoor((s32(*)(void)) & kernel_get_object_addr);
+  svcDebugBackdoor((s32(*)(void)) & kernel_get_object_addr);
   if (get_object_ret) {
     u32 *obj = get_object_ret;
     u32 *refcount_addr = &obj[1];
@@ -173,7 +173,7 @@ void kernel_randomstub(u32 *arg) {
     return;
   }
   randomstub_arg = arg;
-  svcMyBackdoor((s32(*)(void)) & randomstub_wrapper);
+  svcDebugBackdoor((s32(*)(void)) & randomstub_wrapper);
 }
 
 static Result kernel_backdoor(s32 (*callback)(void)) { return callback(); }

--- a/source/backdoor.c
+++ b/source/backdoor.c
@@ -62,7 +62,7 @@ u32 kreadint_debug(u32 *addr) {
   return readint_res;
 }
 
-u32 kreadint_real(u32 *addr) {
+u32 kreadint(u32 *addr) {
   if (addr == 0) {
     printf("kreadint(NULL) -> 0\n");
     return 0;
@@ -72,7 +72,7 @@ u32 kreadint_real(u32 *addr) {
   return readint_res;
 }
 
-void kwriteint_real(u32 *addr, u32 value) {
+void kwriteint(u32 *addr, u32 value) {
   writeint_arg_addr = addr;
   writeint_arg_value = value;
   svcGlobalBackdoor((s32(*)(void)) & writeint);

--- a/source/backdoor_asm.s
+++ b/source/backdoor_asm.s
@@ -1,11 +1,11 @@
 .arm
 .align 4
 
-.section .text.svcMyBackdoor, "ax", %progbits
-.global svcMyBackdoor
-.type svcMyBackdoor, %function
+.section .text.svcDebugBackdoor, "ax", %progbits
+.global svcDebugBackdoor
+.type svcDebugBackdoor, %function
 .align 2
-svcMyBackdoor:
+svcDebugBackdoor:
 	svc 0x2f
 	bx  lr
 

--- a/source/cleanup.c
+++ b/source/cleanup.c
@@ -37,7 +37,7 @@ static void *find_orphan() {
   for (void *current_timer = ktimer_base;
        current_timer < ktimer_end;
        current_timer += KTIMER_OBJECT_SIZE, i++) {
-    void *child = (void *)kreadint(current_timer);
+    void *child = (void *)kreadint_real(current_timer);
 
     if (TOBJ_ADDR_TO_IDX(ktimer_base, current_timer) != i) {
       printf("[!] Got TOBJ_ADDR_TO_IDX(current_timer) != i: 0x%lx != 0x%lx\n",

--- a/source/cleanup.c
+++ b/source/cleanup.c
@@ -37,7 +37,7 @@ static void *find_orphan() {
   for (void *current_timer = ktimer_base;
        current_timer < ktimer_end;
        current_timer += KTIMER_OBJECT_SIZE, i++) {
-    void *child = (void *)kreadint_real(current_timer);
+    void *child = (void *)kreadint(current_timer);
 
     if (TOBJ_ADDR_TO_IDX(ktimer_base, current_timer) != i) {
       printf("[!] Got TOBJ_ADDR_TO_IDX(current_timer) != i: 0x%lx != 0x%lx\n",
@@ -65,7 +65,7 @@ static void *find_orphan() {
   }
 
   /* account for list head */
-  void *first_freed = (void *)kreadint_real(ktimer_pool_head);
+  void *first_freed = (void *)kreadint(ktimer_pool_head);
   if (first_freed) {
     reachable[TOBJ_ADDR_TO_IDX(ktimer_base, first_freed)] = true;
   }
@@ -90,7 +90,7 @@ static void **find_parent() {
   // traverse linked list until next points to userspace
   void *current_node = ktimer_pool_head;
   while (true) {
-    void *next = (void *)kreadint_real(current_node);
+    void *next = (void *)kreadint(current_node);
 
     if (next == (void *)TIMER2_NEXT_KERNEL) {
       return current_node;
@@ -122,6 +122,6 @@ bool cleanup_uaf() {
 
   printf("Found parent and orphan: %p -> %p\n", parent, orphan);
 
-  kwriteint_real((u32 *)parent, (u32)orphan);
+  kwriteint((u32 *)parent, (u32)orphan);
   return true;
 }

--- a/source/exploit.c
+++ b/source/exploit.c
@@ -44,7 +44,7 @@ static u32 fptrs[16] = {
   (u32)&install_global_backdoor,
 };
 
-/* if the UAF succeeded, setup mybackdoor */
+/* if the UAF succeeded, setup global_backdoor */
 static bool try_setup_global_backdoor() {
   Handle timer, timer2;
   Result res;

--- a/source/timer.c
+++ b/source/timer.c
@@ -127,7 +127,7 @@ bool initialize_timer_state() {
     return false;
   }
 
-  if (mybackdoor_installed()) {
+  if (debug_backdoor_installed()) {
     u64 initial = 0;
     if (!get_timer_value(timer2, &initial, NULL)) {
       printf("set_timer: get_timer_value failed\n");


### PR DESCRIPTION
- cleanup functions only allow global backdoor, but `find_orphan` function use mybackdoor function.(`kwriteint`)
- attach `_debug` postfix to luma backdoors, it will reduce confusion
- remove `_real` porstfix
- rename `svcMyBackdoor` to `svcDebugBackdoor`, also rename `mybackdoor_installed` to `debug_backdoor_installed`

Resolve #45 #46 #50 #52 