### PR TITLE
Introduce global table variable

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -1,0 +1,17 @@
+#ifndef __COMMON_H
+#define __COMMON_H
+
+typedef struct version_table {
+  u32 kver;
+  u32 handle_lookup;
+  u32 random_stub;
+  u32 svc_handler_table;
+  u32 svc_acl_check;
+  u32 ktimer_pool_head;
+  u32 ktimer_pool_size;
+  u32 ktimer_base_offset;
+} version_table;
+
+extern version_table *table;
+
+#endif

--- a/include/util.h
+++ b/include/util.h
@@ -1,6 +1,10 @@
 #ifndef __UTIL_H
 #define __UTIL_H
 
+#define CONVERT_VA_L2_TO_PA(addr) ((addr) - 0xFFF00000 + 0x1FF80000)
+#define CONVERT_PA_TO_VA_L1(addr) ((addr) - 0x1FF00000 + 0xDFF00000)
+#define CONVERT_VA_L2_TO_L1(addr) ((addr) - 0xFFF00000 + 0xDFF80000)
+
 void wait_for_user(void);
 
 void *convertVAToPA(const void *addr);

--- a/source/exploit.c
+++ b/source/exploit.c
@@ -2,20 +2,14 @@
 #include <3ds.h>
 #include <stdio.h>
 #include <string.h>
+#include "common.h"
 #include "backdoor.h"
 #include "exploit.h"
 #include "timer.h"
 #include "util.h"
 #include "cleanup.h"
 
-extern void *handle_lookup_kern;
-extern void *RandomStub;
-extern u32 **svc_handler_table_writable;
-extern u32 *svc_acl_check_writable;
-
-u32 ktimer_pool_size;
-u32 ktimer_base_offset;
-void *ktimer_pool_head;
+version_table *table;
 bool is_n3ds;
 
 #define CURRENT_PROCESS 0xFFFF9004
@@ -150,17 +144,6 @@ static void try_once() {
   svcCloseHandle(timer);
 }
 
-typedef struct version_table {
-  u32 kver;
-  u32 handle_lookup;
-  u32 random_stub;
-  u32 svc_handler_table;
-  u32 svc_acl_check;
-  u32 ktimer_pool_head;
-  u32 ktimer_pool_size;
-  u32 ktimer_base_offset;
-} version_table;
-
 // New 3DS
 static version_table n_table[] = {
   {SYSTEM_VERSION(2, 46, 0),  0xFFF18D5C, 0xFFF1B1A4, 0xFFF02300, 0xFFF02258, 0xFFF32238, 0x0E50, 0x4F20},  // 9.0
@@ -195,23 +178,14 @@ static bool initialize_handle_address() {
   u32 kver = osGetKernelVersion();
   APT_CheckNew3DS(&is_n3ds);
 
-  version_table *table = is_n3ds ? n_table : o_table;
+  version_table *preset = is_n3ds ? n_table : o_table;
 
-  while (table->kver) {
-    if (table->kver == kver) {
-      handle_lookup_kern = (void *)table->handle_lookup;
-      RandomStub = (void *)table->random_stub;
-      u32 svc_handler_table_pa = table->svc_handler_table - 0xfff00000 + 0x1ff80000;
-      svc_handler_table_writable = (void *)(svc_handler_table_pa - 0x1ff00000 + 0xdff00000);
-      u32 svc_acl_check_pa = table->svc_acl_check - 0xfff00000 + 0x1ff80000;
-      svc_acl_check_writable = (u32 *)(svc_acl_check_pa - 0x1ff00000 + 0xdff00000);
-
-      ktimer_pool_head = (void *)table->ktimer_pool_head;
-      ktimer_pool_size = table->ktimer_pool_size;
-      ktimer_base_offset = table->ktimer_base_offset;
+  while (preset->kver) {
+    if (preset->kver == kver) {
+      table = preset;
       return true;
     }
-    table = table + 1;
+    preset = preset + 1;
   }
   return false;
 }

--- a/source/timer.c
+++ b/source/timer.c
@@ -5,12 +5,11 @@
 #include <stdio.h>
 #include <3ds.h>
 
+#include "common.h"
 #include "timer.h"
 #include "backdoor.h"
 #include "cleanup.h"
 #include "util.h"
-
-extern void *RandomStub;
 
 static u64 get_tick_offset() {
   /* To find this: run svcGetSystemTick, then do SetTimer(timer, 100000, 100000)
@@ -106,7 +105,7 @@ bool initialize_timer_state() {
 
   set_first_timer(timer);
 
-  if (!set_timer(timer2, (u32)RandomStub)) {
+  if (!set_timer(timer2, table->random_stub)) {
     printf("failed to set timer\n");
     svcCloseHandle(timer2);
     svcCloseHandle(timer);


### PR DESCRIPTION
this variable help to remove multiple global variables

- Recover KTIMER macros
- Add helper macros for convert va to pa
- Add common.h; now source files should know version_table structure